### PR TITLE
fixing ingest config so we can use custom headers in provider requests

### DIFF
--- a/ingest/.config.sample
+++ b/ingest/.config.sample
@@ -1,82 +1,31 @@
-##
-# Provider configuration file
-#
-# See the very bottom of this file for a concise, realistic example
-##
-
-##
-# Global default settings
-##
-[DEFAULT]
-
-    # The git reference (branch name, commit hash, tag) by which MDS is referenced.
-    ref = master
-
-    # The type of the Authorization token header to send
-    # e.g. Authorization: <auth_type> <token>
-    auth_type = Bearer
-
-##
-# Provider-specific settings
-#
-# Replace `provider_id` below with a Provider's UUID, then add the required settings.
-#
-# Create as many provider sections as needed.
-##
-
-## 
-# The provider's UUID from
-# https://raw.githubusercontent.com/CityOfLosAngeles/mobility-data-specification/master/providers.csv
-##
-[provider_id]
-
-    # The authorization token to use for this Provider
-    # Must specify this setting OR client_id + client_secret (see below)
-    token =
-
-    # Settings for an OAuth 2.0 client_credentials grant flow
-    # This flow obtains a limited-time bearer token, and must be
-    # periodically re-run. Check with the Provider for details.
-    token_url =
-    client_id =
-    client_secret =
-    # One or more (separated by commas) scopes requested as part of this grant flow
-    scope =
-
-    # A suffix that comes after the mds_api_url and before the API endpoint for this Provider
-    # Used for customized URLs that include e.g. an Agency name or geographic region
-    mds_api_suffix =
-
-##
-# Below is a more realistic example of what a config file might look like.
-#
-# The example configures 2 different Providers, each with a distinct authorization schemes
-##
-
-##
-# This Provider uses the simpler token style using the default auth_type (Bearer).
-#
-# Includes an API suffix and reference to a specific version.
-#
-# Note we can override official Provider Registry data
-# e.g. a different mds_api_url for testing purposes.
-##
-
-# [6d9ec5e6-8110-4ad7-a5f2-7a2ce45bc1de]
-#     token = QXIkpmTeFeKrzFRpFGGg
-#     mds_api_suffix = agency_xyz
-#     ref = 0.2.0
-#     mds_api_url = https://testing.providerA.co/mds
-
-##
-# This Provider uses the more complex OAuth client_credentials style.
-# Usually this involves registering an application with the Provider's platform,
-# which generates the client_id and client_secret below. Talk to the Provider for
-# more details.
-##
-
-# [72e0b5f4-de11-4b9f-b52f-31fde095ff2f]
-#     token_url = https://developers.providerB.co/api/token
-#     client_id = IjbPIvLWUMej7RMbUykH
-#     client_secret = x0N9e805EGfzfmqDTlnrNhRxub09bllRpLKKE64E
-#     scope = mds.status_changes,mds.trips
+{
+    "DEFAULT": {
+        "_comment": "Global default settings",
+        "ref": "master"
+    },
+    "provider_id_auth_token": {
+        "_comment": "Replace \"provider_id_auth_token\" with a Provider's UUID",
+        "_comment_provider_uuids": "https://raw.githubusercontent.com/CityOfLosAngeles/mobility-data-specification/master/providers.csv",
+        "_comment_authorization": "Authorization token header, e.g. Authorization: <auth_type> <token>",
+        "_comment_headers": "The headers field is optional",
+        "auth_type": "Bearer",
+        "token": "1234567890",
+        "mds_api_suffix": "agency_xyz",
+        "headers": {
+            "optional-custom-header": "1.2.3"
+        }
+    },
+    "provider_id_oauth": {
+        "_comment": "Replace \"provider_id_oauth\" with a Provider's UUID",
+        "_comment_provider_uuids": "https://raw.githubusercontent.com/CityOfLosAngeles/mobility-data-specification/master/providers.csv",
+        "_comment_auth_scope": "One or more (separated by commas) scopes requested as part of this grant flow",
+        "_comment_headers": "The headers field is optional",
+        "token_url": "...",
+        "client_id": "...",
+        "client_secret": "...",
+        "scope": "...",
+        "headers": {
+            "optional-custom-header": "1.2.3"
+        }
+    }
+}

--- a/ingest/.config.sample
+++ b/ingest/.config.sample
@@ -1,29 +1,10 @@
 {
     "DEFAULT": {
-        "_comment": "Global default settings",
         "ref": "master"
     },
-    "provider_id_auth_token": {
-        "_comment": "Replace \"provider_id_auth_token\" with a Provider's UUID",
-        "_comment_provider_uuids": "https://raw.githubusercontent.com/CityOfLosAngeles/mobility-data-specification/master/providers.csv",
-        "_comment_authorization": "Authorization token header, e.g. Authorization: <auth_type> <token>",
-        "_comment_headers": "The headers field is optional",
+    "provider_id": {
         "auth_type": "Bearer",
         "token": "1234567890",
-        "mds_api_suffix": "agency_xyz",
-        "headers": {
-            "optional-custom-header": "1.2.3"
-        }
-    },
-    "provider_id_oauth": {
-        "_comment": "Replace \"provider_id_oauth\" with a Provider's UUID",
-        "_comment_provider_uuids": "https://raw.githubusercontent.com/CityOfLosAngeles/mobility-data-specification/master/providers.csv",
-        "_comment_auth_scope": "One or more (separated by commas) scopes requested as part of this grant flow",
-        "_comment_headers": "The headers field is optional",
-        "token_url": "...",
-        "client_id": "...",
-        "client_secret": "...",
-        "scope": "...",
         "headers": {
             "optional-custom-header": "1.2.3"
         }

--- a/ingest/CONFIG.md
+++ b/ingest/CONFIG.md
@@ -1,0 +1,70 @@
+# Provider configuration file
+
+### Global default settings
+
+`"ref"` is the git refernece (branch name, commit hash, tag) by which MDS is referenced.
+
+```json
+{
+    "DEFAULT": {
+        "ref": "master"
+    },
+    ...
+}
+```
+
+### Provider-specific settings
+
+Each provider block is keyed by the provider's UUID, which can be found here: https://raw.githubusercontent.com/CityOfLosAngeles/mobility-data-specification/master/providers.csv
+
+Create as many provider sections as needed.
+
+###### For auth token flow
+
+To specify the authorization token header to send, fill in the `"auth_type"` and `"token"` fields (e.g. `Authorization: <auth_type> <token>`)
+
+Optional fields:
+* `"mds_api_url"` if the standard mds_api_url found here https://raw.githubusercontent.com/CityOfLosAngeles/mobility-data-specification/master/providers.csv needs to be overridden.
+* `"mds_api_suffix"` for custom paths specified by MDS providers
+* `"headers"` for additional headers needed for the MDS API request
+
+Example config:
+
+```json
+{
+    "DEFAULT": {
+        "ref": "master"
+    },
+    "6d9ec5e6-8110-4ad7-a5f2-7a2ce45bc1de": {
+        "auth_type": "Bearer",
+        "token": "1234567890",
+        "mds_api_suffix": "agency_xyz",
+        "headers": {
+            "optional-custom-header": "1.2.3"
+        }
+    }
+}
+```
+
+###### For OAuth flow
+
+This Provider example uses the more complex OAuth client_credentials style.
+
+Usually this involves registering an application with the Provider's platform, which generates the client_id and client_secret below. Talk to the Provider for more details.
+
+Optional fields:
+* `"headers"` for additional headers needed for the MDS API request
+
+```json
+{
+    "DEFAULT": {
+        "ref": "master"
+    },
+    "72e0b5f4-de11-4b9f-b52f-31fde095ff2f": {
+        "token_url": "https://developers.providerB.co/api/token",
+        "client_id": "IjbPIvLWUMej7RMbUykH",
+        "client_secret": "x0N9e805EGfzfmqDTlnrNhRxub09bllRpLKKE64E",
+        "scope": "mds.status_changes,mds.trips"
+    }
+}
+```

--- a/ingest/main.py
+++ b/ingest/main.py
@@ -162,8 +162,8 @@ def parse_config(path):
 
     print("Reading config file:", path)
 
-    config = ConfigParser()
-    config.read(path)
+    with open(path, 'r') as f:
+        config = json.load(f)
 
     return config
 


### PR DESCRIPTION
the INI config format doesn't allow for nested sections. also, it doesn't allow for keys with a dash (ie. "-") in them. this is needed sometimes for custom headers.

as a result, we cannot specify a "headers" config block within a provider block. this is necessary to do because this is how the mds-provider library expects the "headers" block to be.

in this code block for the Providers initializer, the config is resolved to the section that contains the provider id: https://github.com/CityofSantaMonica/mds-provider/blob/dev/mds/providers.py#L47-L56

then, it takes any other key/value pair in the provider id section and creates attributes based on the names and values in the key/value pairs: https://github.com/CityofSantaMonica/mds-provider/blob/dev/mds/providers.py#L24-L25

the ingest/main.py script also expects the headers attribute to be as part of the provider:
https://github.com/CityofSantaMonica/mds-provider-services/blob/db/ingest/main.py#L479-L482

if we cannot have nested configs, then the provider will never have a headers attribute.