### PR TITLE
add start types and end types to availability query

### DIFF
--- a/analytics/availability.ipynb
+++ b/analytics/availability.ipynb
@@ -146,7 +146,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "q = query.Availability(start_date, end_date, vehicle_types=vehicle_type, table=\"csm_availability\", local=True, debug=True)\n",
+    "q = query.Availability(start_date, end_date, vehicle_types=vehicle_type, table=\"csm_availability\", local=True, debug=True, start_types=\"available\", end_types=[\"reserved\", \"removed\"])\n",
     "data = q.get(provider_name=provider_name)"
    ]
   },
@@ -223,7 +223,7 @@
     "    end = start + oneday\n",
     "    print(f\"Counting {start.strftime('%Y-%m-%d')} to {end.strftime('%Y-%m-%d')}\")\n",
     "    \n",
-    "    q = query.Availability(start, end, vehicle_types=vehicle_type, table=\"csm_availability\", local=True, debug=False)\n",
+    "    q = query.Availability(start, end, vehicle_types=vehicle_type, table=\"csm_availability\", local=True, debug=False, start_types=\"available\", end_types=[\"reserved\", \"removed\"])\n",
     "    data = q.get(provider_name=provider_name)\n",
     "    print(f\"{len(data)} availability records in time period\")\n",
     "    \n",

--- a/analytics/main.py
+++ b/analytics/main.py
@@ -131,10 +131,16 @@ def availability(provider_name, vehicle_type, args):
 
     devices = DeviceCounter(args.start, args.end, local=args.local, debug=args.debug)
 
-    q = query.Availability(args.start, args.end,
+    q = query.Availability(
+        args.start,
+        args.end,
         vehicle_types=vehicle_type,
         table="csm_availability",
-        local=args.local, debug=True)
+        local=args.local,
+        debug=True,
+        start_types="available",
+        end_types=["reserved", "removed"]
+    )
 
     results = {}
 
@@ -155,10 +161,16 @@ def availability(provider_name, vehicle_type, args):
         end = start + oneday
         log(args, f"Counting {start.strftime('%Y-%m-%d')} to {end.strftime('%Y-%m-%d')}")
 
-        _q = query.Availability(start, end,
+        _q = query.Availability(
+            start,
+            end,
             vehicle_types=vehicle_type,
             table="csm_availability",
-            local=args.local, debug=args.debug)
+            local=args.local,
+            debug=args.debug,
+            start_types="available",
+            end_types=["reserved", "removed"]
+        )
 
         _data = _q.get(provider_name)
 

--- a/analytics/query.py
+++ b/analytics/query.py
@@ -187,7 +187,7 @@ class Availability(TimeQuery):
 
         :start_types: event_type or list of event_type to restrict the `start_event_type` (e.g. `available`).
 
-        :end_types: event_type or list of event_type to restrict the `end_event_type` (e.g. `available`).
+        :end_types: event_type or list of event_type to restrict the `end_event_type` (e.g. `removed`, `reserved`).
 
         See `TimeQuery` for additional optional keyword arguments.
         """
@@ -206,7 +206,7 @@ class Availability(TimeQuery):
 
         :start_types: event_type or list of event_type to restrict the start_event_type (e.g. `available`).
 
-        :end_types: event_type or list of event_type to restrict the end_event_type (e.g. `available`).
+        :end_types: event_type or list of event_type to restrict the end_event_type (e.g. `removed`, `reserved`).
 
         See `TimeQuery` for additional optional keyword arguments.
 


### PR DESCRIPTION
without including start types and end types, availability events never end, resulting in a linear increase of availability events over time.

this change adds **removed** and **reserved** events as end_events for an availability window. 

there's an open question about whether **unavailable** should be included as well for end event.