### PR TITLE
remove santa monica filter for csm_availability table

### DIFF
--- a/db/availability/csm.sql
+++ b/db/availability/csm.sql
@@ -27,8 +27,6 @@ SELECT
     end_time
 FROM
     public.availability
-WHERE
-    st_contains(csm_city_boundary(), csm_parse_feature_geom(event_location))
 ORDER BY
     (provider_name, vehicle_type, start_time, end_time)
 


### PR DESCRIPTION
this filter excludes status changes that end outside of santa monica _that have started in santa monica_. this is actually already covered in the MDS spec by the token contained in the geography that should be returned to a particular agency.

for example, if there was an event_type_reason "service_start" in santa monica and then the respective "service_end" happened outside of santa monica (for example, because a ride at some point started in SM and ended outside of SM), then the csm_availability computation should still be able to see that the scooter is no longer in service.

keeping this filter will not allow the csm_availability computation to include these events, which can cause status changes that are relevant to santa monica to be missed.