### PR TITLE
add back default stage first value

### DIFF
--- a/ingest/load.py
+++ b/ingest/load.py
@@ -57,7 +57,7 @@ def load_data(datasource, record_type, **kwargs):
     If :db:, a `ProviderDataLoader` instance, is not given then obtain connection information from the Environment.
     """
     # db connection
-    stage_first = int(kwargs.get("stage_first", False))
+    stage_first = int(kwargs.get("stage_first"))
     on_conflict_update = bool(kwargs.get("on_conflict_update"))
     dbenv = { "stage_first": stage_first, "on_conflict_update": on_conflict_update, **db_env() }
     db = kwargs.get("db", ProviderDataLoader(**dbenv))

--- a/ingest/main.py
+++ b/ingest/main.py
@@ -122,6 +122,7 @@ def setup_cli():
     )
     parser.add_argument(
         "--stage_first",
+        default=3
         help="False to append records directly to the data tables. True to stage in a temp table before UPSERT,\
         or an int to stage in a temp table before UPSERT, with increasing randomness to the temp table name."
     )

--- a/ingest/main.py
+++ b/ingest/main.py
@@ -122,7 +122,7 @@ def setup_cli():
     )
     parser.add_argument(
         "--stage_first",
-        default=3
+        default=True,
         help="False to append records directly to the data tables. True to stage in a temp table before UPSERT,\
         or an int to stage in a temp table before UPSERT, with increasing randomness to the temp table name."
     )


### PR DESCRIPTION
if you run the script without specifying any `--stage_first` cli arg, the script fails with this error:

```
Traceback (most recent call last):
  File "main.py", line 362, in <module>
    ingest(mds.STATUS_CHANGES, client=client, **kwargs)
  File "main.py", line 285, in ingest
    load_data(datasource, record_type, **kwargs)
  File "/home/jovyan/work/mds/load.py", line 60, in load_data
    stage_first = int(kwargs.get("stage_first", False))
TypeError: int() argument must be a string, a bytes-like object or a number, not 'NoneType'
```

this is because there is no default specified in the ConfigParser object, and as a result the `kwargs` object has a key/value pair like `"stage_first": None`

i looked through the git history to find out what the default should be, and it looks like stage_first used to be `3`, so i added that back