### PR TITLE
timeline dedupe view is missing an order by

### DIFF
--- a/db/availability/device_event_timeline_dedupe.sql
+++ b/db/availability/device_event_timeline_dedupe.sql
@@ -48,6 +48,7 @@ FROM
                 AND ((_left.event_type = 'available'::event_types AND _right.event_type = 'available'::event_types) OR
                 -- both the same, not 'avail' -> 
                     (_left.event_type <> 'available'::event_types AND _right.event_type <> 'available'::event_types))
+            ORDER BY _left.vehicle_id, _left.event_time
         ) dupe
         WHERE
             dupe.condition

--- a/db/availability/device_event_timeline_dedupe.sql
+++ b/db/availability/device_event_timeline_dedupe.sql
@@ -48,7 +48,7 @@ FROM
                 AND ((_left.event_type = 'available'::event_types AND _right.event_type = 'available'::event_types) OR
                 -- both the same, not 'avail' -> 
                     (_left.event_type <> 'available'::event_types AND _right.event_type <> 'available'::event_types))
-            ORDER BY _left.vehicle_id, _left.event_time
+            ORDER BY _left.provider_id, _left.device_id, _left.event_time
         ) dupe
         WHERE
             dupe.condition


### PR DESCRIPTION
causes row_nums to be non-contiguous for some vehicle_ids in the resulting view, which causes problems downstream (failed self join and resulting NULL event time ends, which looks like vehicles are still on the streets)