### PR TITLE
Order rows by event_time after deduping them.

### DIFF
--- a/db/availability/device_event_timeline_dedupe.sql
+++ b/db/availability/device_event_timeline_dedupe.sql
@@ -6,7 +6,7 @@ CREATE VIEW public.device_event_timeline_dedupe AS
 
 SELECT
     *,
-    row_number() OVER () AS row_num
+    row_number() OVER (PARTITION BY provider_id, device_id ORDER BY event_time) AS row_num
 FROM
     (SELECT -- the non-duplicated records
         provider_id,
@@ -46,7 +46,7 @@ FROM
                 AND (_left.row_num + 1) = _right.row_num
                 -- both 'available' -> user/data/transmission error
                 AND ((_left.event_type = 'available'::event_types AND _right.event_type = 'available'::event_types) OR
-                -- both the same, not 'avail' -> 
+                -- both the same, not 'avail' ->
                     (_left.event_type <> 'available'::event_types AND _right.event_type <> 'available'::event_types))
         ) dupe
         WHERE


### PR DESCRIPTION
This matters because otherwise rows are not sorted by device_id in the join output, and the query in inactive_windows.sql will fail to correctly set an end_time on its windows.