### PR TITLE
fix analytics runtime error

### DIFF
--- a/analytics/main.py
+++ b/analytics/main.py
@@ -89,7 +89,7 @@ def parse_time_range(args):
         Helper to parse different textual representations into datetime
         """
         try:
-            return datetime.fromtimestamp(int(data), timezone.utc)
+            return datetime.utcfromtimestamp(int(data))
         except:
             return dateutil.parser.parse(data)
 


### PR DESCRIPTION
when running `docker-compose run --rm analytics [OPTIONS]`, we get a runtime error:

```
Traceback (most recent call last):
  File "main.py", line 92, in _to_datetime
    return datetime.fromtimestamp(int(data), timezone.utc)
NameError: name 'timezone' is not defined
```

seems like the intent was to parse the --start or --end argument as a epoch second timestamp in timezone utc, so we can just use the `datetime.utcfromtimestamp` method for this