### PR TITLE
fix ingest runtime error when reading from source file

### DIFF
--- a/ingest/main.py
+++ b/ingest/main.py
@@ -265,13 +265,13 @@ def ingest(record_type, **kwargs):
     if validating:
         ref = kwargs.get("ref")
         datasource = validate_data(datasource, record_type, ref)
+
+        # clean up missing data
+        for k in [k for k in datasource.keys()]:
+            if not datasource[k] or len(datasource[k]) < 1:
+                del datasource[k]
     else:
         print("Skipping data validation")
-
-    # clean up missing data
-    for k in [k for k in datasource.keys()]:
-        if not datasource[k] or len(datasource[k]) < 1:
-            del datasource[k]
 
     # output to files if needed
     output = kwargs.get("output")


### PR DESCRIPTION
when running the ingest using the `--source` flag on a file that was outputted by the ingest with `--no_validate` it has a runtime error:

```
Traceback (most recent call last):
  File "main.py", line 305, in <module>
    ingest(mds.STATUS_CHANGES, **vars(args))
  File "main.py", line 272, in ingest
    for k in [k for k in datasource.keys()]:
AttributeError: 'list' object has no attribute 'keys'
```

after looking through the git history, i found this commit that committed the code that's throwing: https://github.com/CityofSantaMonica/mds-provider-services/commit/09a7c80adb75934f64ad6d87a5c055dab6ce8753#diff-9475fd5345582638fa5bb17d2fafcab8R270

there's value in running the ingest with `--no_validate` because for very large files (ie. trips/status changes data containing a month's worth of data) it takes a long time. and typically when we ingest and save into files, we validate anyway

`validate_data(...)` returns a dict, so we should clean up missing data using this block of code only when we validate_data